### PR TITLE
이미지 업로드 관련 수정

### DIFF
--- a/src/main/java/project/maybedo/image/Image.java
+++ b/src/main/java/project/maybedo/image/Image.java
@@ -18,12 +18,9 @@ public class Image {
     @Column(name = "image_id")
     private int id;
 
-    private String url;
+    private String originFileName;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    @JsonBackReference
-    private Member member;
+    private String url;
 
     public void updateUrl(String newUrl) {
         this.url = newUrl;

--- a/src/main/java/project/maybedo/image/Image.java
+++ b/src/main/java/project/maybedo/image/Image.java
@@ -1,5 +1,6 @@
 package project.maybedo.image;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.*;
 import project.maybedo.member.Member;
 
@@ -21,6 +22,7 @@ public class Image {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @JsonBackReference
     private Member member;
 
     public void updateUrl(String newUrl) {

--- a/src/main/java/project/maybedo/image/ImageController.java
+++ b/src/main/java/project/maybedo/image/ImageController.java
@@ -16,10 +16,10 @@ import javax.servlet.http.HttpSession;
 public class ImageController {
     private final ImageService imageService;
     @PostMapping("/upload")
-    public ResponseDto<Integer> upload(ImageUploadDTO imageUploadDTO, HttpSession session) {
+    public ResponseDto<String> upload(ImageUploadDTO imageUploadDTO, HttpSession session) {
         Member member = (Member)session.getAttribute("principal");
-        imageService.upload(imageUploadDTO, member.getUsername());
+        String fileName = imageService.upload(imageUploadDTO, member.getUsername());
 
-        return new ResponseDto<Integer>(HttpStatus.OK.value(), 1);
+        return new ResponseDto<String>(HttpStatus.OK.value(), fileName);
     }
 }

--- a/src/main/java/project/maybedo/image/ImageController.java
+++ b/src/main/java/project/maybedo/image/ImageController.java
@@ -16,9 +16,8 @@ import javax.servlet.http.HttpSession;
 public class ImageController {
     private final ImageService imageService;
     @PostMapping("/upload")
-    public ResponseDto<String> upload(ImageUploadDTO imageUploadDTO, HttpSession session) {
-        Member member = (Member)session.getAttribute("principal");
-        String fileName = imageService.upload(imageUploadDTO, member.getUsername());
+    public ResponseDto<String> upload(ImageUploadDTO imageUploadDTO) {
+        String fileName = imageService.upload(imageUploadDTO);
 
         return new ResponseDto<String>(HttpStatus.OK.value(), fileName);
     }

--- a/src/main/java/project/maybedo/image/ImageRepository.java
+++ b/src/main/java/project/maybedo/image/ImageRepository.java
@@ -4,5 +4,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import project.maybedo.member.Member;
 
 public interface ImageRepository extends JpaRepository<Image, Integer> {
-    Image findByMember(Member member);
 }

--- a/src/main/java/project/maybedo/image/ImageService.java
+++ b/src/main/java/project/maybedo/image/ImageService.java
@@ -20,9 +20,6 @@ public class ImageService {
     private final MemberRepository memberRepository;
     private final ImageRepository imageRepository;
 
-    @Value("${file.path}")
-    private String uploadFolder;
-
     public String upload(ImageUploadDTO imageUploadDTO, String username) {
         Member member = memberRepository.findByUsername(username);
         MultipartFile file = imageUploadDTO.getFile();
@@ -32,8 +29,10 @@ public class ImageService {
         int idx = originFileName.lastIndexOf('.');
         String extension = originFileName.substring(idx);
 
+        String projectPath = System.getProperty("user.dir") + "/src/main/images/"; // 파일이 저장될 폴더의 경로
+        System.out.println("projectPath"+projectPath);
         String resultFileName = uuid + extension;
-        File destinationFile = new File(uploadFolder + resultFileName);
+        File destinationFile = new File(projectPath + resultFileName);
 
         try {
             file.transferTo(destinationFile);
@@ -41,17 +40,18 @@ public class ImageService {
             Image image = imageRepository.findByMember(member);
             if (image != null) {
                 // 사용자의 이전 프로필 이미지를 로컬 저장소에서 제거
-                String prevFilename = image.getUrl().substring("/profileImages/".length());
-                File deleteFile = new File(uploadFolder + prevFilename);
-                deleteFile.delete();
+//                String prevFilename = image.getUrl().substring("/images/".length());
+//                System.out.println("prevFilename"+prevFilename);
+//                File deleteFile = new File(projectPath + prevFilename);
+//                deleteFile.delete();
 
                 // 이미지가 이미 존재하면 url 업데이트
-                image.updateUrl("/profileImages/" + resultFileName);
+                image.updateUrl(resultFileName);
             } else {
                 // 이미지가 없으면 객체 생성 후 저장
                 image = Image.builder()
                         .member(member)
-                        .url("/profileImages/" + resultFileName)
+                        .url(resultFileName)
                         .build();
             }
             imageRepository.save(image);
@@ -65,7 +65,7 @@ public class ImageService {
         Member member = memberRepository.findByUsername(username);
         Image image = imageRepository.findByMember(member);
 
-        String defaultImageUrl = "/profileImages/anonymous.png";
+        String defaultImageUrl = "anonymous.png";
 
         if (image == null) {
             return ImageResponseDTO.builder()

--- a/src/main/java/project/maybedo/image/ImageService.java
+++ b/src/main/java/project/maybedo/image/ImageService.java
@@ -37,6 +37,11 @@ public class ImageService {
 
             Image image = imageRepository.findByMember(member);
             if (image != null) {
+                // 사용자의 이전 프로필 이미지를 로컬 저장소에서 제거
+                String prevFilename = image.getUrl().substring("/profileImages/".length());
+                File deleteFile = new File(uploadFolder + prevFilename);
+                deleteFile.delete();
+
                 // 이미지가 이미 존재하면 url 업데이트
                 image.updateUrl("/profileImages/" + imageFileName);
             } else {

--- a/src/main/java/project/maybedo/member/Member.java
+++ b/src/main/java/project/maybedo/member/Member.java
@@ -51,6 +51,7 @@ public class Member {
     private List<Join> join_list = new ArrayList<>();
 
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonManagedReference
     private Image image;
 
 }

--- a/src/main/java/project/maybedo/member/Member.java
+++ b/src/main/java/project/maybedo/member/Member.java
@@ -27,7 +27,7 @@ public class Member {
     private String email;
     private String password;
     private String message;
-//    private String photo_url;
+    private String photo_url;
     private String original_file_name;
     private String stored_file_name;
     private double achievement;
@@ -50,8 +50,8 @@ public class Member {
     @JsonManagedReference
     private List<Join> join_list = new ArrayList<>();
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JsonManagedReference
-    private Image image;
+//    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//    @JsonManagedReference
+//    private Image image;
 
 }

--- a/src/main/java/project/maybedo/member/MemberService.java
+++ b/src/main/java/project/maybedo/member/MemberService.java
@@ -9,6 +9,7 @@ import project.maybedo.group.GroupService;
 import project.maybedo.group.domain.Group;
 import project.maybedo.group.groupJoin.Join;
 import project.maybedo.group.groupJoin.JoinRepository;
+import project.maybedo.image.ImageRepository;
 import project.maybedo.member.memberDTO.MemberJoinDTO;
 import project.maybedo.member.memberDTO.MemberUpdateDTO;
 import project.maybedo.todo.Todo;
@@ -22,7 +23,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JoinRepository joinRepository;
-
+    private final ImageRepository imageRepository;
 
     // 회원가입(email, username, password)
     @Transactional
@@ -36,6 +37,8 @@ public class MemberService {
             new_member.setEmail(memberJoinDTO.getEmail());
             new_member.setUsername(memberJoinDTO.getUsername());
             new_member.setPassword(memberJoinDTO.getPassword());
+            new_member.setPhoto_url(memberJoinDTO.getPhoto_url());
+
             return memberRepository.save(new_member).getId();
         }
         return (-1);
@@ -65,8 +68,8 @@ public class MemberService {
             update_member.setEmail(memberUpdateDTO.getEmail());
         if (memberUpdateDTO.getMessage() != null)
             update_member.setMessage(memberUpdateDTO.getMessage());
-//        if (memberUpdateDTO.getPhoto_url() != null)
-//            update_member.setPhoto_url(memberUpdateDTO.getPhoto_url());
+        if (memberUpdateDTO.getPhoto_url() != null)
+            update_member.setPhoto_url(memberUpdateDTO.getPhoto_url());
         memberRepository.save(update_member);
         return (update_member);
     }

--- a/src/main/java/project/maybedo/member/memberDTO/MemberJoinDTO.java
+++ b/src/main/java/project/maybedo/member/memberDTO/MemberJoinDTO.java
@@ -8,4 +8,5 @@ public class MemberJoinDTO {
     String name;
     String username;
     String password;
+    String photo_url;
 }

--- a/src/main/java/project/maybedo/member/memberDTO/MemberUpdateDTO.java
+++ b/src/main/java/project/maybedo/member/memberDTO/MemberUpdateDTO.java
@@ -7,6 +7,6 @@ public class MemberUpdateDTO {
     String name;
     String email;
     String message;  // 한줄소개
-//    String photo_url;
+    String photo_url;
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,12 @@ spring:
         generate_statistics: true
   mvc:
     static-path-pattern: /images/**
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 
 logging.level:
   org.hibernate.SQL: debug
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,9 +18,9 @@ spring:
         show_sql: true
         format_sql: true
         generate_statistics: true
+  mvc:
+    static-path-pattern: /images/**
+
 
 logging.level:
   org.hibernate.SQL: debug
-
-file:
-  path: /Users/${USER}/Desktop/project/image


### PR DESCRIPTION
- 멤버 조회할 때 이미지와 멤버 순환 참조 오류 발생
- 사진 업로드 반환값을 파일명으로
- 파일 저장 경로 프로젝트 내부로 변경
- 파일 저장 이름을 uuid_원본 파일명 -> uuid.확장자 형식으로 변경
- upload api를 호출하는 경우는 image 저장만 수행하고, 사용자 및 그룹을 생성 및 수정하는 경우에 image_url 필드를 변경시키도록 수정