### PR TITLE
[feat]: 투두 달성률 체크 streakRepository에서 찾아서 갱신해줌

### DIFF
--- a/src/main/java/project/maybedo/member/Member.java
+++ b/src/main/java/project/maybedo/member/Member.java
@@ -29,7 +29,6 @@ public class Member {
     private String password;
     private String message;
     private String image_path;
-    private double achievement;
 
     @JsonManagedReference
     @OneToMany(mappedBy = "member")

--- a/src/main/java/project/maybedo/member/MemberService.java
+++ b/src/main/java/project/maybedo/member/MemberService.java
@@ -123,16 +123,4 @@ public class MemberService {
         return (myGroups);
     }
 
-    // 달성률 매일 밤 초기화
-    @Scheduled(cron = "0 0 0 * * ?")  // 매일 밤 자정에 초기화 해주는 크론식
-    public void resetAchievement() {
-        List<Member> members = memberRepository.findAll();
-
-        for (Member member : members) {
-            member.setAchievement(0.0);
-        }
-
-        memberRepository.saveAll(members);
-    }
-
 }

--- a/src/main/java/project/maybedo/member/MemberService.java
+++ b/src/main/java/project/maybedo/member/MemberService.java
@@ -16,9 +16,11 @@ import project.maybedo.image.ImageRepository;
 import project.maybedo.image.ImageService;
 import project.maybedo.member.memberDTO.MemberJoinDTO;
 import project.maybedo.member.memberDTO.MemberUpdateDTO;
+import project.maybedo.streak.StreakService;
 import project.maybedo.todo.Todo;
 
 import javax.servlet.http.HttpSession;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +33,7 @@ public class MemberService {
     private final JoinRepository joinRepository;
     private final ImageService imageService;
     private final ImageRepository imageRepository;
+    private final StreakService streakService;
 
     // 회원가입(email, username, password)
     @Transactional
@@ -51,7 +54,9 @@ public class MemberService {
             } else {
                 new_member.setImage_path("");
             }
-            return memberRepository.save(new_member).getId();
+            memberRepository.save(new_member);
+            streakService.setUserStreak(new_member, LocalDate.now());
+            return (new_member.getId());
         }
         return (-1);
     }

--- a/src/main/java/project/maybedo/streak/StreakController.java
+++ b/src/main/java/project/maybedo/streak/StreakController.java
@@ -3,10 +3,12 @@ package project.maybedo.streak;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import project.maybedo.dto.ResponseDto;
 import project.maybedo.group.domain.Group;
 import project.maybedo.member.Member;
+import project.maybedo.member.MemberRepository;
 
 import javax.servlet.http.HttpSession;
 import java.time.LocalDate;
@@ -17,24 +19,25 @@ import java.util.List;
 public class StreakController {
 
     private final StreakService streakService;
+    private final MemberRepository memberRepository;
 
-    // 오늘 달성률 조회
-    @GetMapping("/streak")
-    public ResponseDto<Streak> todayStreak (HttpSession session)
+    // 특정 사용자의 오늘 달성률 조회
+    @GetMapping("/streak/{username}")
+    public ResponseDto<Streak> todayStreak (@PathVariable String username)
     {
         LocalDate today = LocalDate.now();
-        Member member = (Member) session.getAttribute("principal");
+        Member member = memberRepository.findByUsername(username);
 
         Streak streak = streakService.getTodayStreak(today, member);
         return new ResponseDto<Streak> (HttpStatus.OK.value(), streak);
     }
 
 
-    // 모든 날짜 달성률 조회
-    @GetMapping("/streaks")
-    public ResponseDto<List<Streak>> allStreaks (HttpSession session)
+    // 특정 사용자의 모든 날짜 달성률 조회
+    @GetMapping("/streaks/{username}")
+    public ResponseDto<List<Streak>> allStreaks (@PathVariable String username)
     {
-        Member member = (Member) session.getAttribute("principal");
+        Member member = memberRepository.findByUsername(username);
 
         List<Streak> streaks = streakService.getAllStreaks(member);
         return new ResponseDto<List<Streak>> (HttpStatus.OK.value(), streaks);

--- a/src/main/java/project/maybedo/streak/StreakService.java
+++ b/src/main/java/project/maybedo/streak/StreakService.java
@@ -1,8 +1,10 @@
 package project.maybedo.streak;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import project.maybedo.member.Member;
+import project.maybedo.member.MemberRepository;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,6 +14,7 @@ import java.util.List;
 public class StreakService {
 
     private final StreakRepository streakRepository;
+    private final MemberRepository memberRepository;
 
     public Streak getTodayStreak(LocalDate today, Member member)
     {
@@ -23,5 +26,22 @@ public class StreakService {
     {
         List<Streak> streaks = streakRepository.findByMember(member);
         return (streaks);
+    }
+
+    // 모든 멤버 매일 밤 12시에 새로운 스트릭 생성
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void setTodayStreak() {
+        List<Member> members = memberRepository.findAll();
+        LocalDate today = LocalDate.now();
+
+        for (Member member : members) {
+
+            Streak streak = new Streak();
+            streak.setDate(today);
+            streak.setPercent(0);
+            streak.setMember(member);
+
+            streakRepository.save(streak);
+        }
     }
 }

--- a/src/main/java/project/maybedo/streak/StreakService.java
+++ b/src/main/java/project/maybedo/streak/StreakService.java
@@ -28,6 +28,20 @@ public class StreakService {
         return (streaks);
     }
 
+    // 특정 유저의 오늘 스트릭 생성
+    public void setUserStreak(Member member, LocalDate today) {
+
+        if (streakRepository.findByMemberAndDate(member, today) == null)
+        {
+            Streak streak = new Streak();
+
+            streak.setDate(today);
+            streak.setPercent(0);
+            streak.setMember(member);
+            streakRepository.save(streak);
+        }
+    }
+
     // 모든 멤버 매일 밤 12시에 새로운 스트릭 생성
     @Scheduled(cron = "0 0 0 * * ?")
     public void setTodayStreak() {
@@ -35,13 +49,7 @@ public class StreakService {
         LocalDate today = LocalDate.now();
 
         for (Member member : members) {
-
-            Streak streak = new Streak();
-            streak.setDate(today);
-            streak.setPercent(0);
-            streak.setMember(member);
-
-            streakRepository.save(streak);
+            setUserStreak(member, today);
         }
     }
 }

--- a/src/main/java/project/maybedo/todo/TodoService.java
+++ b/src/main/java/project/maybedo/todo/TodoService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import project.maybedo.group.groupJoin.Join;
 import project.maybedo.member.Member;
 import project.maybedo.member.MemberRepository;
+import project.maybedo.streak.Streak;
+import project.maybedo.streak.StreakRepository;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,6 +18,7 @@ public class TodoService
 {
     private final TodoRepository todoRepository;
     private final MemberRepository memberRepository;
+    private final StreakRepository streakRepository;
 
     // 달성률 체크
     public void checkAchievement(Member member, LocalDate todoDate)
@@ -35,8 +38,10 @@ public class TodoService
                     success++;
             }
             double achievementPercentage = (double) success / size * 100;
-            member.setAchievement(achievementPercentage);
-            memberRepository.save(member);
+
+            Streak st = streakRepository.findByMemberAndDate(member, today);
+            st.setPercent(achievementPercentage);
+            streakRepository.save(st);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:


### PR DESCRIPTION
- Member 내의 achievement 삭제
- 매일 밤 12시에 사용자마다 오늘 날짜의 streak 생성됨 (크론 사용)
- 달성률 갱신을 streak 리포지토리에서 오늘 날짜의 streak을 찾아와 갱신시켜줌